### PR TITLE
fix TEP-613: исправлена ошибка с выходом текста за пределы ячейки таблицы

### DIFF
--- a/src/assets/index-view.css
+++ b/src/assets/index-view.css
@@ -15,6 +15,7 @@ table .quill-table__cell {
 	position: relative;
     border: 1px solid #DCDCDC;
 	padding: 2px 5px;
+	word-wrap: break-word;
 }
 
 .quill-table__cell-line {


### PR DESCRIPTION
## Тип вносимых изменений

-   Багфикс

## Вносимые изменения

Добавляется стиль, который разрешает перенос длинного текста на следующую строку

## Внешние источники

-   [Задача](https://yt.tilda.team/issue/TEP-613/Tablica-v-Quill) в ютрек
